### PR TITLE
Add CORS middleware to express.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/koltyakov/sp-rest-proxy#readme",
   "dependencies": {
     "body-parser": "^1.15.2",
+    "cors": "^2.8.1",
     "cpass": "^1.0.0",
     "express": "^4.14.0",
     "lodash": "^4.15.0",

--- a/src/server.js
+++ b/src/server.js
@@ -2,6 +2,7 @@
 
 var Cpass = require("cpass");
 var cpass = new Cpass();
+var cors = require("cors");
 
 var spf = spf || {};
 spf.restProxy = function() {
@@ -179,6 +180,7 @@ spf.restProxy = function() {
         _self.initContext(function() {
             app.use(bodyParser.urlencoded({ extended: true }));
             app.use(bodyParser.json());
+            app.use(cors());
             app.use("*/_api", _self.routers.apiRouter);
             app.use("/", _self.routers.staticRouter);
             app.listen(_self.port);


### PR DESCRIPTION
Enable Cross Origin Resource Sharing so modern browsers don't throw errors when attempting to use HTTP methods other than GET.