### PR TITLE
send response.body back to the requestor

### DIFF
--- a/src/routers/soap.ts
+++ b/src/routers/soap.ts
@@ -54,7 +54,7 @@ export class SoapRouter {
                             if (this.settings.debugOutput) {
                                 console.log(response.statusCode, response.body);
                             }
-                            res.send(response);
+                            res.send(response.body);
                             res.end();
                         });
                 })


### PR DESCRIPTION
because the browser will be expecting an xml response