### PR TITLE
Allows all HTTPS requests to share the same connection to eliminate d…

### DIFF
--- a/src/routers/csom.ts
+++ b/src/routers/csom.ts
@@ -8,12 +8,14 @@ export class CsomRouter {
 
     private spr: ISPRequest;
     private ctx: IProxyContext;
+    private agent: any;
     private settings: IProxySettings;
     private util: ProxyUtils;
 
-    constructor(context: IProxyContext, settings: IProxySettings) {
+    constructor(context: IProxyContext, settings: IProxySettings, agent: any) {
         this.ctx = context;
         this.settings = settings;
+        this.agent = agent;
         this.util = new ProxyUtils(this.ctx);
     }
 
@@ -53,7 +55,8 @@ export class CsomRouter {
                     return this.spr.post(endpointUrl, {
                         headers: headers,
                         body: csomPackage,
-                        json: false
+                        json: false,
+                        agent: this.agent
                     });
                 })
                 .then((response: any) => {

--- a/src/routers/genericGet.ts
+++ b/src/routers/genericGet.ts
@@ -11,13 +11,15 @@ export class GetRouter {
 
     private ctx: IProxyContext;
     private settings: IProxySettings;
+    private agent: any;
     private staticLibPathExists: boolean;
     private util: ProxyUtils;
     private spr: ISPRequest;
 
-    constructor(context: IProxyContext, settings: IProxySettings) {
+    constructor(context: IProxyContext, settings: IProxySettings, agent: any) {
         this.ctx = context;
         this.settings = settings;
+        this.agent = agent;
         this.staticLibPathExists = fs.existsSync(settings.staticLibPath);
         this.util = new ProxyUtils(this.ctx);
     }
@@ -101,7 +103,10 @@ export class GetRouter {
             endpointUrl = axdUrlArr[0].replace('://', '___').split('/')[0].replace('___', '://') +
                 '/ScriptResource.axd' + axdUrlArr[1];
 
-            request.get({ uri: endpointUrl }).pipe(res);
+            request.get({
+              uri: endpointUrl,
+              agent: this.agent
+            }).pipe(res);
             return;
         }
 

--- a/src/routers/genericPost.ts
+++ b/src/routers/genericPost.ts
@@ -8,12 +8,14 @@ export class PostRouter {
 
     private spr: ISPRequest;
     private ctx: IProxyContext;
+    private agent: any;
     private settings: IProxySettings;
     private util: ProxyUtils;
 
-    constructor(context: IProxyContext, settings: IProxySettings) {
+    constructor(context: IProxyContext, settings: IProxySettings, agent: any) {
         this.ctx = context;
         this.settings = settings;
+        this.agent = agent;
         this.util = new ProxyUtils(this.ctx);
     }
 
@@ -61,6 +63,7 @@ export class PostRouter {
                     this.spr.post(endpointUrl, {
                         headers: headers,
                         body: postBody,
+                        agent: this.agent,
                         ...(<any>options)
                     })
                         .then((response: any) => {

--- a/src/routers/restBatch.ts
+++ b/src/routers/restBatch.ts
@@ -7,12 +7,14 @@ export class RestBatchRouter {
 
     private spr: ISPRequest;
     private ctx: IProxyContext;
+    private agent: any;
     private settings: IProxySettings;
     private util: ProxyUtils;
 
-    constructor(context: IProxyContext, settings: IProxySettings) {
+    constructor(context: IProxyContext, settings: IProxySettings, agent: any) {
         this.ctx = context;
         this.settings = settings;
+        this.agent = agent;
         this.util = new ProxyUtils(this.ctx);
     }
 
@@ -98,7 +100,8 @@ export class RestBatchRouter {
                 return this.spr.post(endpointUrlStr, {
                     headers: requestHeadersPass,
                     body: reqBodyData,
-                    json: false
+                    json: false,
+                    agent: this.agent
                 });
             })
             .then((resp: any) => {

--- a/src/routers/restGet.ts
+++ b/src/routers/restGet.ts
@@ -7,12 +7,14 @@ export class RestGetRouter {
 
     private spr: ISPRequest;
     private ctx: IProxyContext;
+    private agent: any;
     private settings: IProxySettings;
     private util: ProxyUtils;
 
-    constructor(context: IProxyContext, settings: IProxySettings) {
+    constructor(context: IProxyContext, settings: IProxySettings, agent: any) {
         this.ctx = context;
         this.settings = settings;
+        this.agent = agent;
         this.util = new ProxyUtils(this.ctx);
     }
 
@@ -50,7 +52,8 @@ export class RestGetRouter {
         }
 
         this.spr.get(endpointUrl, {
-            headers: requestHeadersPass
+            headers: requestHeadersPass,
+            agent: this.agent
         })
             .then((response: any) => {
                 if (this.settings.debugOutput) {

--- a/src/routers/restPost.ts
+++ b/src/routers/restPost.ts
@@ -7,12 +7,14 @@ export class RestPostRouter {
 
     private spr: ISPRequest;
     private ctx: IProxyContext;
+    private agent: any;
     private settings: IProxySettings;
     private util: ProxyUtils;
 
-    constructor(context: IProxyContext, settings: IProxySettings) {
+    constructor(context: IProxyContext, settings: IProxySettings, agent: any) {
         this.ctx = context;
         this.settings = settings;
+        this.agent = agent;
         this.util = new ProxyUtils(this.ctx);
     }
 
@@ -97,6 +99,7 @@ export class RestPostRouter {
                 return this.spr.post(endpointUrlStr, {
                     headers: requestHeadersPass,
                     body: reqBodyData,
+                    agent: this.agent,
                     ...jsonOption
                 });
             })

--- a/src/routers/soap.ts
+++ b/src/routers/soap.ts
@@ -8,12 +8,14 @@ export class SoapRouter {
 
     private spr: ISPRequest;
     private ctx: IProxyContext;
+    private agent: any;
     private settings: IProxySettings;
     private util: ProxyUtils;
 
-    constructor(context: IProxyContext, settings: IProxySettings) {
+    constructor(context: IProxyContext, settings: IProxySettings, agent: any) {
         this.ctx = context;
         this.settings = settings;
+        this.agent = agent;
         this.util = new ProxyUtils(this.ctx);
     }
 
@@ -48,7 +50,8 @@ export class SoapRouter {
                     this.spr.post(endpointUrl, {
                         headers: headers,
                         body: soapBody,
-                        json: false
+                        json: false,
+                        agent: this.agent
                     })
                         .then((response: any) => {
                             if (this.settings.debugOutput) {


### PR DESCRIPTION
…uplicate SSL handshakes - which previously happened for every new request - which experimentally has resulted in ~200ms extra time for each response.

The motivation was for an app we are building at Insiten which issues > 200 requests in order to load the app. Loading the app in development was noticeably slow compared to when loading the app in production - which does not use the proxy and therefore Chrome can reuse the SSL connection.

This is a Proof of Concept and is probably not the best way to implement it, but it has been tested to work. An alternate implementation might add the agent property to the proxy context, but I didn't want to have to change the node-sp-auth-config module as well.