### PR TITLE
Keep alive agent is implementation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+When submitting a PR, please make sure you to:
+
+- submit the PR to the `dev` branch, **not** the `master` branch
+- in the body, reference the issue that it closes by number in the format `Closes #000`
+- provide brief description of introduced enhancements

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sp-rest-proxy",
   "description": "SharePoint REST API Proxy for Node.js and Express local serve",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "main": "./dist/index.js",
   "typings": "./dist/index",
   "scripts": {

--- a/src/RestProxy.ts
+++ b/src/RestProxy.ts
@@ -28,7 +28,6 @@ export default class RestProxy {
     private app: express.Application;
     private settings: IProxySettings;
     private routers: IRouters;
-    private agent: https.Agent;
 
     constructor(settings: IProxySettings = {}) {
         this.settings = {

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,5 +1,6 @@
 import { IAuthOptions } from 'node-sp-auth';
 import { Router } from 'express';
+import * as https from 'https';
 
 export interface IProxySettings {
     configPath?: string;
@@ -13,6 +14,7 @@ export interface IProxySettings {
     debugOutput?: boolean;
     metadata?: any;
     silentMode?: boolean;
+    agent?: https.Agent;
 }
 
 export interface IProxyContext {

--- a/src/routers/csom.ts
+++ b/src/routers/csom.ts
@@ -53,7 +53,8 @@ export class CsomRouter {
                     return this.spr.post(endpointUrl, {
                         headers: headers,
                         body: csomPackage,
-                        json: false
+                        json: false,
+                        agent: this.util.isUrlHttps(endpointUrl) ? this.settings.agent : undefined
                     });
                 })
                 .then((response: any) => {

--- a/src/routers/genericGet.ts
+++ b/src/routers/genericGet.ts
@@ -101,13 +101,17 @@ export class GetRouter {
             endpointUrl = axdUrlArr[0].replace('://', '___').split('/')[0].replace('___', '://') +
                 '/ScriptResource.axd' + axdUrlArr[1];
 
-            request.get({ uri: endpointUrl }).pipe(res);
+            request.get({
+                uri: endpointUrl,
+                agent: this.util.isUrlHttps(endpointUrl) ? this.settings.agent : undefined
+            }).pipe(res);
             return;
         }
 
         this.spr.get(endpointUrl, {
             headers: requestHeadersPass,
-            ...(<any>advanced)
+            ...(<any>advanced),
+            agent: this.util.isUrlHttps(endpointUrl) ? this.settings.agent : undefined
         })
             .then((response: any) => {
                 if (!this.settings.silentMode) {

--- a/src/routers/genericPost.ts
+++ b/src/routers/genericPost.ts
@@ -61,7 +61,8 @@ export class PostRouter {
                     this.spr.post(endpointUrl, {
                         headers: headers,
                         body: postBody,
-                        ...(<any>options)
+                        ...(<any>options),
+                        agent: this.util.isUrlHttps(endpointUrl) ? this.settings.agent : undefined
                     })
                         .then((response: any) => {
                             if (this.settings.debugOutput) {

--- a/src/routers/restBatch.ts
+++ b/src/routers/restBatch.ts
@@ -98,7 +98,8 @@ export class RestBatchRouter {
                 return this.spr.post(endpointUrlStr, {
                     headers: requestHeadersPass,
                     body: reqBodyData,
-                    json: false
+                    json: false,
+                    agent: this.util.isUrlHttps(endpointUrlStr) ? this.settings.agent : undefined
                 });
             })
             .then((resp: any) => {

--- a/src/routers/restGet.ts
+++ b/src/routers/restGet.ts
@@ -50,7 +50,8 @@ export class RestGetRouter {
         }
 
         this.spr.get(endpointUrl, {
-            headers: requestHeadersPass
+            headers: requestHeadersPass,
+            agent: this.util.isUrlHttps(endpointUrl) ? this.settings.agent : undefined
         })
             .then((response: any) => {
                 if (this.settings.debugOutput) {

--- a/src/routers/restPost.ts
+++ b/src/routers/restPost.ts
@@ -97,7 +97,8 @@ export class RestPostRouter {
                 return this.spr.post(endpointUrlStr, {
                     headers: requestHeadersPass,
                     body: reqBodyData,
-                    ...jsonOption
+                    ...jsonOption,
+                    agent: this.util.isUrlHttps(endpointUrlStr) ? this.settings.agent : undefined
                 });
             })
             .then((resp: any) => {

--- a/src/routers/soap.ts
+++ b/src/routers/soap.ts
@@ -48,7 +48,8 @@ export class SoapRouter {
                     this.spr.post(endpointUrl, {
                         headers: headers,
                         body: soapBody,
-                        json: false
+                        json: false,
+                        agent: this.util.isUrlHttps(endpointUrl) ? this.settings.agent : undefined
                     })
                         .then((response: any) => {
                             if (this.settings.debugOutput) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -23,6 +23,18 @@ export class ProxyUtils {
         return this.spr;
     }
 
+    public isOnPrem(url: string): boolean {
+        return url.indexOf('.sharepoint.com') === -1 && url.indexOf('.sharepoint.cn') === -1;
+    }
+
+    public isUrlHttps(url: string): boolean {
+        return url.split('://')[0].toLowerCase() === 'https';
+    }
+
+    public isUrlAbsolute(url: string): boolean {
+        return url.indexOf('http:') === 0 || url.indexOf('https:') === 0;
+    }
+
     public buildEndpointUrl = (reqUrl: string) => {
         let siteUrlParsed = url.parse(this.ctx.siteUrl);
         let reqPathName = '';

--- a/test/integration/proxy.spec.ts
+++ b/test/integration/proxy.spec.ts
@@ -128,7 +128,7 @@ describe(`Proxy tests`, () => {
 
             });
 
-            it(`should get lists on web`, function(done: MochaDone): void {
+            it(`should get lists on the web`, function(done: MochaDone): void {
                 this.timeout(30 * 1000);
 
                 Promise.all([
@@ -146,7 +146,7 @@ describe(`Proxy tests`, () => {
 
             });
 
-            it('should create new list', function(done: MochaDone): void {
+            it('should create a new list', function(done: MochaDone): void {
                 this.timeout(30 * 1000);
 
                 axios.post(`${proxyRootUri}/_api/web/lists`, {
@@ -174,7 +174,7 @@ describe(`Proxy tests`, () => {
 
             });
 
-            it('should create list item', function(done: MochaDone): void {
+            it('should create a list item', function(done: MochaDone): void {
                 this.timeout(30 * 1000);
 
                 let listUri = `${proxyRootUri}/_api/web/lists/getByTitle('${testVariables.newListName}')`;
@@ -200,7 +200,7 @@ describe(`Proxy tests`, () => {
 
             });
 
-            it('should update list item', function(done: MochaDone): void {
+            it('should update a list item', function(done: MochaDone): void {
                 this.timeout(30 * 1000);
 
                 let listUri = `${proxyRootUri}/_api/web/lists/getByTitle('${testVariables.newListName}')`;
@@ -231,7 +231,7 @@ describe(`Proxy tests`, () => {
 
             });
 
-            it('should delete list item', function(done: MochaDone): void {
+            it('should delete a list item', function(done: MochaDone): void {
                 this.timeout(30 * 1000);
 
                 let listUri = `${proxyRootUri}/_api/web/lists/getByTitle('${testVariables.newListName}')`;
@@ -286,7 +286,7 @@ describe(`Proxy tests`, () => {
                 });
 
                 // Add test to check if items were physically created
-                it('should create list items in batch (local endpoints)', function(done: MochaDone): void {
+                it('should create list items in a batch (local endpoints)', function(done: MochaDone): void {
                     this.timeout(30 * 1000);
 
                     let items = [ 'Batman', 'Iron man' ];
@@ -343,7 +343,7 @@ describe(`Proxy tests`, () => {
                 });
 
                 // Add test to check if items were physically created
-                it('should create list items in batch', function(done: MochaDone): void {
+                it('should create list items in a batch', function(done: MochaDone): void {
                     this.timeout(30 * 1000);
 
                     let dragons = [ 'Jineoss',  'Zyna', 'Bothir', 'Jummerth', 'Irgonth', 'Kilbiag',
@@ -401,7 +401,7 @@ describe(`Proxy tests`, () => {
                 });
 
                 // Add test to check if items were physically updated
-                it('should update list items in batch', function(done: MochaDone): void {
+                it('should update list items in a batch', function(done: MochaDone): void {
                     this.timeout(30 * 1000);
 
                     let listUri = `${proxyRootUri}/_api/web/lists/getByTitle('${testVariables.newListName}')`;
@@ -467,7 +467,7 @@ describe(`Proxy tests`, () => {
                 });
 
                 // Add test to check if items were physically deleted
-                it('should delete list items in batch', function(done: MochaDone): void {
+                it('should delete list items in a batch', function(done: MochaDone): void {
                     this.timeout(30 * 1000);
 
                     let listUri = `${proxyRootUri}/_api/web/lists/getByTitle('${testVariables.newListName}')`;
@@ -571,7 +571,7 @@ describe(`Proxy tests`, () => {
 
             // TODO: Download attachment and compare with local one
 
-            it('should delete list', function(done: MochaDone): void {
+            it('should delete a list', function(done: MochaDone): void {
                 this.timeout(30 * 1000);
 
                 axios.post(`${proxyRootUri}/_api/web/lists/getByTitle('${testVariables.newListName}')`, null, {
@@ -590,7 +590,7 @@ describe(`Proxy tests`, () => {
 
             });
 
-            it('should create document library', function(done: MochaDone): void {
+            it('should create a document library', function(done: MochaDone): void {
                 this.timeout(30 * 1000);
 
                 axios.post(`${proxyRootUri}/_api/web/lists`, {
@@ -614,7 +614,7 @@ describe(`Proxy tests`, () => {
 
             });
 
-            it('should add document', function(done: MochaDone): void {
+            it('should add a document', function(done: MochaDone): void {
                 this.timeout(30 * 1000);
 
                 let attachmentFile: string = path.join(__dirname, './attachments/image.png');
@@ -645,7 +645,7 @@ describe(`Proxy tests`, () => {
 
             // TODO: Download documents and compare with local one
 
-            it('should delete document library', function(done: MochaDone): void {
+            it('should delete a document library', function(done: MochaDone): void {
                 this.timeout(30 * 1000);
 
                 axios.post(`${proxyRootUri}/_api/web/lists/getByTitle('${testVariables.newDocLibName}')`, null, {


### PR DESCRIPTION
This PR is based on ideas suggested by @airportyh [PR](https://github.com/koltyakov/sp-rest-proxy/pull/22), but with minor changes and HTTPS/HTTP aware for enabling agent only for HTTPS.

Integration tests showed up to 55% increase in speed in On-Prem SSL environment and up to 30% in SPO.

The figures are relative but include some runs with the following proxy operations:
- should get web's title
- should work with shorthand URIs
- should get lists on the web
- should create a new list
- should create a list item
- should update a list item
- should delete a list item
- should fetch minimalmetadata
- should fetch nometadata
- should create list items in a batch
- should create list items in a batch
- should update list items in a batch
- should delete list items in a batch
- should add item's attachment
- should delete a list
- should create a document library
- should add a document
- should delete a document library
- should get web's title with SOAP
- should get web's title with CSOM


