### PR TITLE
Allow successful file uploads.

### DIFF
--- a/src/RestProxy.ts
+++ b/src/RestProxy.ts
@@ -91,6 +91,8 @@ export default class RestProxy {
           }
         });
 
+        let bodyParserUrlencoded = bodyParser.urlencoded({ extended: true });
+
         // REST - Files and attachments
         this.routers.apiRestRouter.post(
           '/*(/attachmentfiles/add|/files/add)*',
@@ -123,12 +125,14 @@ export default class RestProxy {
         //  CSOM requests (XML)
         this.routers.apiCsomRouter.post(
           '/*',
+          bodyParserUrlencoded,
           (new CsomRouter(context, this.settings)).router
         );
 
         //  SOAP requests (XML)
         this.routers.apiSoapRouter.post(
           '/*',
+          bodyParserUrlencoded,
           (new SoapRouter(context, this.settings)).router
         );
 
@@ -141,10 +145,9 @@ export default class RestProxy {
         // Generic POST
         this.routers.genericPostRouter.post(
           '/*',
+          bodyParserUrlencoded,
           (new PostRouter(context, this.settings)).router
         );
-
-        this.app.use(bodyParser.urlencoded({ extended: true }));
 
         this.app.use(cors());
         this.app.use('*/_api', this.routers.apiRestRouter);

--- a/src/routers/restPost.ts
+++ b/src/routers/restPost.ts
@@ -106,7 +106,11 @@ export class RestPostRouter {
           console.log(resp.statusCode, resp.body);
         }
         res.status(resp.statusCode);
-        res.json(resp.body);
+        if (typeof resp.body === 'string') {
+          res.json(JSON.parse(resp.body));
+        } else {
+          res.json(resp.body);
+        }
       })
       .catch((err: any) => {
         res.status(err.statusCode >= 100 && err.statusCode < 600 ? err.statusCode : 500);


### PR DESCRIPTION
Fixes #35.

Removed urlencoded body parser as a global catch-all middleware, and instead using it for specific URL patterns. For the
upload API, I found the need to manually parse the JSON string from the response,
I am not 100% sure why.
