### PR TITLE
If a post request results in an error response, the error is now forw…

### DIFF
--- a/src/routers/genericPost.ts
+++ b/src/routers/genericPost.ts
@@ -58,7 +58,7 @@ export class PostRouter {
             processData: false
           };
 
-          this.spr.post(endpointUrl, {
+          return this.spr.post(endpointUrl, {
             headers: headers,
             body: postBody,
             ...options as any,
@@ -73,6 +73,9 @@ export class PostRouter {
               res.contentType(response.headers['content-type']);
 
               res.send(response.body);
+            })
+            .catch((err: any) => {
+              throw(err);
             });
         })
         .catch((err: any) => {


### PR DESCRIPTION
`Closes #49`

If a post request results in an error response, the error is now forwarded to the client. earlier behavior was that the error was dumped to console.

When submitting a PR, please make sure you to:

- submit the PR to the `dev` branch, **not** the `master` branch
- in the body, reference the issue that it closes by number in the format `Closes #000`
- provide brief description of introduced enhancements
