### PR TITLE
SOAPAction headers are now passed through the proxy.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sp-rest-proxy",
-  "version": "2.7.5-beta2",
+  "version": "2.7.5-beta5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -108,6 +108,15 @@
           "requires": {
             "import-local": "^1.0.0",
             "jest-cli": "^22.4.4"
+          }
+        },
+        "rimraf": {
+          "version": "2.5.4",
+          "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+          "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+          "dev": true,
+          "requires": {
+            "glob": "^7.0.5"
           }
         }
       }
@@ -7641,9 +7650,9 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.5.4",
-      "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-      "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
         "glob": "^7.0.5"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "typings": "./dist/index/RestProxy",
   "scripts": {
     "serve": "ts-node ./src/server",
-    "build": "npm run tslint && rm -rf ./dist && tsc -p .",
+    "build": "npm run tslint && rimraf ./dist && tsc -p .",
     "tslint": "tslint -p .",
     "test": "ts-node ./test/init && mocha --opts test/mocha.opts || ECHO.",
     "test:manual": "ts-node ./test/manual/server",
@@ -60,6 +60,7 @@
     "eslint-config-standard": "^12.0.0",
     "minimist": "^1.2.0",
     "mocha": "^5.2.0",
+    "rimraf": "^2.6.2",
     "sp-pnp-node": "^2.1.3",
     "ts-node": "^7.0.1",
     "tslint": "^5.11.0",

--- a/src/core/routers/soap.ts
+++ b/src/core/routers/soap.ts
@@ -25,6 +25,7 @@ export class SoapRouter extends BasicRouter {
         .then(opt => {
           const headers = {
             ...opt.headers,
+            'SOAPAction': req.headers.soapaction,
             'Accept': 'application/xml, text/xml, */*; q=0.01',
             'Content-Type': 'text/xml;charset="UTF-8"',
             'X-Requested-With': 'XMLHttpRequest'


### PR DESCRIPTION
There is no outstanding issue related to this, but it does resolve an issue that occurs when making SOAP requests.

Certain SOAP requests are required to include the SOAPAction header.  The SOAPAction header will vary based on the the request being made.  This change will now forward the SOAPAction from the original request to the one made by the proxy.