### PR TITLE
Fixes "Bad Request - Invalid Verb" Errors

### DIFF
--- a/src/core/routers/restPost.ts
+++ b/src/core/routers/restPost.ts
@@ -71,6 +71,10 @@ export class RestPostRouter extends BasicRouter {
         // JSOM empty object
         if (typeof body === 'object' && Object.keys(body).length === 0) {
           body = '{}';
+          // When content-length is set to 0 in this case - since body has been
+          // forcably set to "{}" - the content length becomes invalid. The following
+          // line removes the content-length header to avoid errors downstream.
+          delete headers['content-length'];
         }
         return this.spr.post(endpointUrl, { headers, body, ...jsonOption, agent });
       })


### PR DESCRIPTION
This PR fixes this issue: https://github.com/koltyakov/sp-rest-proxy/issues/62.

Fixed subsequent request errors after sending a content length 0 is sent when body is "{}".
To test/retest: the errorneous code path happens when a POST request is made with an empty body -
maybe happen with deletes as well. We have had issues with the file checkout API. The thing that
made this hard to diagnose was that the error did not surface with the request that caused the problem,
but rather with the subsequent request after the problematic request which uses the same connection from the connection pool - I confirmed this hypothesis by un-sharing the connection agent between the different requests. I believe that for that reason, it took use checkout and unchecking out the same file about 3-5 times before this error would occur but not on the checkout or uncheckout API calls, but on the API call to fetch the document items.

In the fix, I thought it would be more intuitive to set the `Content-Length` to 2: `headers['Content-Type'] = '2';`, but somehow, that didn't work: the problem recurred. Simply deleting the header solves the problem. I was not able to explain that - any insight on this would be welcome.

I am not sure how to give you a reproducible test, because mine depends on my environment. If you'd like to see it, contact me on Slack.